### PR TITLE
Fix incorrect target path for from imports

### DIFF
--- a/importgraph.py
+++ b/importgraph.py
@@ -70,7 +70,7 @@ class ImportAction:
 
     def _last_module_in_path(self, path: ModulePath) -> ModulePath:
         """Given a path, find the last item that refers to a module object"""
-        for sub_path in (path[:-i] for i in range(len(path))):
+        for sub_path in (path[:i] for i in reversed(range(len(path) + 1))):
             if self._get_module('.'.join(sub_path)) is not None:
                 return sub_path
         return tuple()

--- a/tests/test_importgraph.py
+++ b/tests/test_importgraph.py
@@ -57,3 +57,14 @@ class TestImportAction:
         import_paths_set = set(import_paths)
         assert len(import_paths) == len(import_paths_set)
         assert import_paths_set == expected_result
+
+    def test_last_module_in_path_returns_full_path_module_not_none(
+        self,
+        import_action: ImportAction,
+    ) -> None:
+        import_action._get_module = MagicMock()
+        path = ('some', 'module', 'path')
+
+        result = import_action._last_module_in_path(path)
+
+        assert result == path


### PR DESCRIPTION
Fixes a bug in `_last_module_in_path` where it would first check the
empty path instead of the full path.